### PR TITLE
Fixes component name

### DIFF
--- a/packages/client/src/components/TestJsx3.re
+++ b/packages/client/src/components/TestJsx3.re
@@ -1,0 +1,20 @@
+[@bs.config {jsx: 3}];
+
+[@react.component]
+let make = (~text, ~children) =>
+  <div> {text |> Utils.ste} {children |> ReasonReact.array} </div>;
+
+// Read docs how to Step by step gone into PPX3
+// Docs: https://reasonml.github.io/reason-react/docs/en/jsx#upgrade-script
+// Usages: <TestJsx3.Jsx2 text="Text from props"> {"Children Text" |> Utils.ste} </TestJsx3.Jsx2>
+
+module Jsx2 = {
+  let component = ReasonReact.statelessComponent("TestJsx3");
+  /* `children` is not labelled, as it is a regular parameter in version 2 of JSX */
+  let make = (~text, children) =>
+    ReasonReactCompat.wrapReactForReasonReact(
+      make,
+      makeProps(~text, ~children, ()),
+      children,
+    );
+};


### PR DESCRIPTION
#406 

Upgrading PPX2 on PPX3 of react components at once it is a huge and complex issue. To make it gently and step by step authors of ResonReact propose to us to make hybrid components and only then make a jump to pp3. I propose to add the examaple of this component since there are some tricks in "children" property.